### PR TITLE
Use HTTPS for Jekyll's site url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
 title: CBusJS
-email: 
+email:
 description: "Columbus JavaScript User Group"
 baseurl: ""
-url: "http://cbusjs.github.io"
+url: "https://cbusjs.github.io"
 twitter_username: cbusjs
 github_username:  cbusjs
 paginate: 3


### PR DESCRIPTION
The [HTTPS site](https://cbusjs.github.io/) has issues with loading some assets, because the site URL is set to the [HTTP site](http://cbusjs.github.io/). This is caused by browsers refusing to load insecure resources on HTTPS sites (since the asset paths are currently only pointing to HTTP resources). With this change, all assets (and other links that include the site URL) should use HTTPS. Fortunately, browsers support loading secure resources on insecure sites, so the HTTP site should still work even with HTTPS resources.

If this is merged, the HTTPS site should hopefully be safe to use. In that case, please update links to the site to use HTTPS.

# Warning
I am unfortunately unable to test this, since the configuration is specific to GitHub Pages and I cannot host HTTPS sites on my GitHub account (because I have a custom domain). If you merge, please make sure both versions of the site still render properly.