### PR TITLE
Fix sidebar style and links

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,8 +1,9 @@
 <div class="sidebar">
-
-  <h1 class="site-title"><span><a href="/">{{ site.title }}</a></span></h1>
-
-  <h2 class="description"><span>{{ site.description }}</span></h2>
+  
+  <div class="titles clearfix">
+    <h1 class="site-title"><span><a href="/">{{ site.title }}</a></span></h1>
+    <h2 class="description"><span>{{ site.description }}</span></h2>
+  </div>
 
   <div class="left-menu">
     <ul>
@@ -12,7 +13,7 @@
     </ul>
   </div>
 
-  <div class="location">
+  <div class="location clearfix">
     <h3>We meet every third Wednesday at 6:30 p.m.</h3>
 
     <div class="address">
@@ -24,16 +25,16 @@
     </div>
 
     <a href="/map">
-      <img src="images/map-pin.svg">
+      <img src="/images/map-pin.svg">
     </a>
   </div>
 
   <div class="social-icons">
     <a href="https://github.com/cbusjs" title="https://github.com/cbusjs">
-      <span class="github"><img src="images/github.svg"></span>
+      <span class="github"><img src="/images/github.svg"></span>
     </a>
     <a href="https://twitter.com/cbusjs" title="https://twitter.com/cbusjs">
-      <span class="twitter"><img src="images/twitter.svg" ></span>
+      <span class="twitter"><img src="/images/twitter.svg" ></span>
     </a>
   </div>
 

--- a/css/main.css
+++ b/css/main.css
@@ -126,8 +126,13 @@ h1.site-title {
 }
 
 
-h1.site-title span {
+.titles {
+  width: 330px;
+  margin: 0 auto;
   background: rgba(0,0,0,0.6);
+}
+
+h1.site-title span {
   padding: 8px 5px 1px;
 }
 
@@ -156,7 +161,6 @@ h2.description {
 }
 
 h2.description span {
-  background: rgba(0,0,0,0.6);
   padding: 7px 5px 5px;
 }
 
@@ -223,7 +227,7 @@ h2.speaker-date {
 }
 
 .location {
-  padding: 15px 30px 50px;
+  padding: 15px 30px 8px;
   width: 290px;
   background: rgba(0,0,0,0.6);
   margin: 0 auto 30px;
@@ -459,6 +463,10 @@ button:focus {
   h2.description {
     font-size: 16px;
     margin-bottom: 10px;
+  }
+
+  .titles {
+    width: 290px;
   }
 
   .sidebar {


### PR DESCRIPTION
- Add clearfix class to meeting info box and combine title and description into a single div with background.
- Sidebar image links needed to be of the form: `/<link>` in order to be found on pages other than root.